### PR TITLE
[CEN-1559] add path of ade mock to verify vat

### DIFF
--- a/src/main/java/it/gov/pagopa/bpd/io_backend/api/VerificaApi.java
+++ b/src/main/java/it/gov/pagopa/bpd/io_backend/api/VerificaApi.java
@@ -7,15 +7,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 import io.swagger.annotations.Api;
 import it.gov.pagopa.bpd.io_backend.model.ade.VerificaPartitaIva;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Api("AdE_verifica_CF")
-@RequestMapping("/WsAnagraficaDL78Web/services/VerificaAnagraficaDL78InterfaceEndpoint")
 @Validated
 public interface VerificaApi {
 
-    @GetMapping(value = "/verifica/{partitaIva}", produces = { "application/json", "application/problem+json" })
+    @GetMapping(value = "/WsAnagraficaDL78Web/services/VerificaAnagraficaDL78InterfaceEndpoint/verifica/{partitaIva}", produces = { "application/json", "application/problem+json" })
     ResponseEntity<VerificaPartitaIva> getPartitaIva(@PathVariable("partitaIva") String partitaIva);
 
+    @GetMapping(value = "/partita-iva/v0/verifica/{partitaIva}", produces = { "application/json", "application/problem+json" })
+    ResponseEntity<VerificaPartitaIva> getVAT(@PathVariable("partitaIva") String partitaIva);
+
 }
+
 

--- a/src/main/java/it/gov/pagopa/bpd/io_backend/api/VerificaApiController.java
+++ b/src/main/java/it/gov/pagopa/bpd/io_backend/api/VerificaApiController.java
@@ -44,6 +44,10 @@ public class VerificaApiController extends StatelessController implements Verifi
 		this.random = new Random();
 	}
 
+	public ResponseEntity<VerificaPartitaIva> getVAT(@PathVariable("partitaIva") final String partitaIva) {
+		return this.getPartitaIva(partitaIva);
+	}
+
 	public ResponseEntity<VerificaPartitaIva> getPartitaIva(@PathVariable("partitaIva") final String partitaIva) {
         final String accept = request.getHeader("Accept");
         if (//accept != null && accept.contains("application/json") &&


### PR DESCRIPTION
This PR adds a path that allows to reach the API that simulates the AdE VAT verification, this new path allows to align the url to the original one of AdE, so that changing only the base URL, it's possible to switch from the production environment to the mocked environment.