### PR TITLE
[RTD-1789] switch service from loadbalancer to clusterip

### DIFF
--- a/manifests/service.yml
+++ b/manifests/service.yml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
     name: cstariobackendtest
 spec:
-    type: LoadBalancer
+    type: ClusterIP
     ports:
     - port: 8080
     selector:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes
Switch service from LoadBalancer to ClusterIP to prevent external direct access to the pod.

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

#### Has This Been Tested?

- [ ] Yes
- [ ] No
